### PR TITLE
Videos now prioritize playing to the end over slideshow timer (and random sort in personal list)

### DIFF
--- a/BooruSlideshow/js/mvc/personal_list_controller.js
+++ b/BooruSlideshow/js/mvc/personal_list_controller.js
@@ -30,6 +30,18 @@ class PersonalListController
         this._view.currentVideoClickedEvent.attach(function() {
             _this.currentSlideClicked();
         });
+
+        this._view.currentImageStartedEvent.attach(function(){
+            _this.currentImageStarted();
+        })
+
+        this._view.currentVideoStartedEvent.attach(function(){
+            _this.currentVideoStarted();
+        })
+
+        this._view.currentVideoLoopedEvent.attach(function(){
+            _this.currentVideoLooped();
+        })
         
         this._view.currentVideoVolumeChangedEvent.attach(function() {
             _this.videoVolumeChanged();
@@ -127,6 +139,18 @@ class PersonalListController
 		
         this._model.setVideoVolume(videoVolume);
         this._model.setVideoMuted(videoMuted);
+    }
+
+    currentImageStarted(){
+        this._model.unlockSlideshow();
+    }
+
+    currentVideoStarted(){
+        this._model.lockSlideshow();
+    }
+
+    currentVideoLooped(){
+        this._model.unlockSlideshow();
     }
 
     firstNavButtonClicked()

--- a/BooruSlideshow/js/mvc/personal_list_view.js
+++ b/BooruSlideshow/js/mvc/personal_list_view.js
@@ -7,6 +7,9 @@ class PersonalListView
         this.currentImageClickedEvent = new Event(this);
         this.currentVideoClickedEvent = new Event(this);
         this.currentVideoVolumeChangedEvent = new Event(this);
+        this.currentVideoStartedEvent = new Event(this);
+        this.currentImageStartedEvent = new Event(this);
+        this.currentVideoLoopedEvent = new Event(this);
         this.filterButtonClickedEvent = new Event(this);
         this.firstNavButtonClickedEvent = new Event(this);
         this.previousNavButtonClickedEvent = new Event(this);
@@ -73,6 +76,7 @@ class PersonalListView
             _this.updateAutoFitSlide();
         });
 
+
         this._model.personalListLoadedEvent.attach(function () {
             _this.clearWarningMessage();
             _this.clearInfoMessage();
@@ -103,6 +107,13 @@ class PersonalListView
             }
             
             _this.currentVideoVolumeChangedEvent.notify();
+        });
+
+        this.uiElements.currentVideo.addEventListener('timeupdate', () => {
+            if (this.uiElements.currentVideo.currentTime >= this.uiElements.currentVideo.duration - 0.5) {
+                this.videoLoopedOnce = true;
+                _this.currentVideoLoopedEvent.notify();
+            }
         });
         
         this.uiElements.firstNavButton.addEventListener('click', function() {
@@ -223,6 +234,7 @@ class PersonalListView
         this.uiElements.autoFitSlideCheckBox.addEventListener('change', function () {
             _this.autoFitSlideChangedEvent.notify();
         });
+
     }
 
     openCurrentSlide()
@@ -354,9 +366,12 @@ class PersonalListView
 		
 		this.clearVideo();
         this.updateSlideSize();
+
+        this.currentImageStartedEvent.notify();
     }
 	
 	displayVideo(currentSlide) {
+
         var currentVideo = this.uiElements.currentVideo;
 
         currentVideo.src = currentSlide.fileUrl;
@@ -366,6 +381,8 @@ class PersonalListView
         this.updateSlideSize();
 		this.updateVideoVolume();
 		this.updateVideoMuted();
+
+        this.currentVideoStartedEvent.notify();
     }
 	
 	getVideoVolume() {

--- a/BooruSlideshow/js/mvc/slideshow_controller.js
+++ b/BooruSlideshow/js/mvc/slideshow_controller.js
@@ -24,6 +24,18 @@ class SlideshowController
             _this.videoVolumeChanged();
         });
 
+        this._view.currentImageLoadedEvent.attach(function(){
+            _this.currentImageStarted();
+        })
+
+        this._view.currentVideoLoadedEvent.attach(function(){
+            _this.currentVideoStarted();
+        })
+
+        this._view.currentVideoLoopedEvent.attach(function(){
+            _this.currentVideoLooped();
+        })
+
         this._view.firstNavButtonClickedEvent.attach(function () {
             _this.firstNavButtonClicked();
         });
@@ -180,6 +192,18 @@ class SlideshowController
 		
         this._model.setVideoVolume(videoVolume);
         this._model.setVideoMuted(videoMuted);
+    }
+
+    currentImageStarted(){
+        this._model.unlockSlideshow();
+    }
+
+    currentVideoStarted(){
+        this._model.lockSlideshow();
+    }
+
+    currentVideoLooped(){
+        this._model.unlockSlideshow();
     }
 
     firstNavButtonClicked()

--- a/BooruSlideshow/js/mvc/slideshow_model.js
+++ b/BooruSlideshow/js/mvc/slideshow_model.js
@@ -42,6 +42,7 @@ class SlideshowModel{
         this.isPlaying = false;
         this.timer = null;
         this.timerMs = 0;
+        this.slideshowLocked = false;
 
         this.sitesManager = null;
 
@@ -301,27 +302,32 @@ class SlideshowModel{
         var millisecondsPerSlide = this.secondsPerSlide * 1000;
 	    
         var _this = this;
+        var intervalMs = 100;
+        var acumMs = 0;
 
-        this.timer = setTimeout(function() {
-            if (_this.hasNextSlide())
-            {
-                // Continue slideshow
-                _this.increaseCurrentSlideNumber();
+        this.timer = setInterval(function() {
+            if (!_this.slideshowLocked && acumMs >= millisecondsPerSlide){
+                clearInterval(this.timer);
+                if (_this.hasNextSlide())
+                {
+                    // Continue slideshow
+                    _this.increaseCurrentSlideNumber();
+                }
+                else if (_this.isTryingToLoadMoreSlides())
+                    {
+                        // Wait for loading images/videos to finish
+                        _this.sitesManager.runCodeWhenFinishGettingMoreSlides(function(){
+                            _this.tryToStartCountdown();
+                        });
+                }
+                else
+                {
+                    // Loop when out of images/videos
+                    _this.setSlideNumberToFirst();
+                }
             }
-            else if (_this.isTryingToLoadMoreSlides())
-            {
-                // Wait for loading images/videos to finish
-                _this.sitesManager.runCodeWhenFinishGettingMoreSlides(function(){
-                    _this.tryToStartCountdown();
-                });
-            }
-            else
-            {
-                // Loop when out of images/videos
-                _this.setSlideNumberToFirst();
-            }
-		
-        }, millisecondsPerSlide);
+            acumMs += intervalMs;
+        }, intervalMs);
     }
 
     restartSlideshowIfOn()
@@ -345,6 +351,14 @@ class SlideshowModel{
         this.isPlaying = false;
 
         this.playingChangedEvent.notify();
+    }
+
+    lockSlideshow(){
+        this.slideshowLocked = true;
+    }
+
+    unlockSlideshow(){
+        this.slideshowLocked = false;
     }
 
     hasAtLeastOneOnlineSiteSelected()

--- a/BooruSlideshow/js/mvc/slideshow_view.js
+++ b/BooruSlideshow/js/mvc/slideshow_view.js
@@ -5,8 +5,11 @@ class SlideshowView
         this.uiElements = uiElements;
         
         this.currentImageClickedEvent = new Event(this);
+        this.currentImageLoadedEvent = new Event(this);
         this.currentVideoClickedEvent = new Event(this);
         this.currentVideoVolumeChangedEvent = new Event(this);
+        this.currentVideoLoadedEvent = new Event(this);
+        this.currentVideoLoopedEvent = new Event(this);
         this.searchButtonClickedEvent = new Event(this);
         this.firstNavButtonClickedEvent = new Event(this);
         this.previousNavButtonClickedEvent = new Event(this);
@@ -189,6 +192,13 @@ class SlideshowView
             }
             
             _this.currentVideoVolumeChangedEvent.notify();
+        });
+
+        this.uiElements.currentVideo.addEventListener('timeupdate', () => {
+            if (this.uiElements.currentVideo.currentTime >= this.uiElements.currentVideo.duration - 0.5) {
+                this.videoLoopedOnce = true;
+                _this.currentVideoLoopedEvent.notify();
+            }
         });
         
         this.uiElements.firstNavButton.addEventListener('click', function() {
@@ -527,6 +537,7 @@ class SlideshowView
 		
 		this.clearVideo();
         this.updateSlideSize();
+        this.currentImageLoadedEvent.notify();
     }
 	
 	displayVideo(currentSlide) {
@@ -539,6 +550,7 @@ class SlideshowView
         this.updateSlideSize();
 		this.updateVideoVolume();
 		this.updateVideoMuted();
+        this.currentVideoLoadedEvent.notify();
     }
 	
 	getVideoVolume() {

--- a/BooruSlideshow/js/objects/data_loader.js
+++ b/BooruSlideshow/js/objects/data_loader.js
@@ -302,6 +302,7 @@ class DataLoader
     {
         chrome.storage.sync.set({'autoFitSlide': this._model.autoFitSlide});
     }
+
 	
     saveIncludeImages()
     {

--- a/BooruSlideshow/personal_list.html
+++ b/BooruSlideshow/personal_list.html
@@ -31,7 +31,6 @@
 				</div>
 			</div>
 			<div id="filter">
-				SLIDESHOW AND PRELOADING DON'T WORK YET!<br>
 				<input id="filter-text" type="search" /><br>
 				<button id="filter-button">Filter</button>
 			</div>


### PR DESCRIPTION
Changed the timer of the slideshow and personal list to an interval
Model has a slideshow lock in place that gets activated when a video (and not an image) is loaded
View now notifies when the video has looped, allowing for some future shenanigans, now it just turns off the lock of the slideshow that prevents the ticker from changing to the next slide if the video hasn't played entirely once.

The new timer system also has personal list slideshow mode working again, even though the sites manager callback for when the content has finished loading has been deleted and the slidwshow mode of the personal list just does not care about that (yet).

No option to override this has been added, as this sounds like the proper intended behaviour (fast paced short content, allowing short loops to run multiple times before switching and full length long videos)

Additionally, "sort:random" now works as a filter in the personal list. Any "sort" is detected and filtered out of the tags list, but if sort:random is used, then the filtered list will be shuffled, which is neat.
